### PR TITLE
Feat: add 6 unit tests for DateUtils.IsSameLocalTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -650,11 +650,6 @@
    <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12-SNAPSHOT</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${commons.pmd.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -650,6 +650,11 @@
    <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.12-SNAPSHOT</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${commons.pmd.version}</version>

--- a/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java
@@ -763,6 +763,80 @@ public class DateUtilsTest extends AbstractLangTest {
     }
 
     @Test
+    public void testIsSameLocalTime_millsecondReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2004, Calendar.JULY, 9, 13, 45, 0);
+        cala.set(Calendar.MILLISECOND, 1);
+        calb.set(2004, Calendar.JULY, 9, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
+    public void testIsSameLocalTime_secondReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2004, Calendar.JULY, 9, 13, 45, 1);
+        cala.set(Calendar.MILLISECOND, 0);
+        calb.set(2004, Calendar.JULY, 9, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
+    public void testIsSameLocalTime_minuteReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2004, Calendar.JULY, 9, 13, 46, 0);
+        cala.set(Calendar.MILLISECOND, 0);
+        calb.set(2004, Calendar.JULY, 9, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
+    public void testIsSameLocalTime_dayOfyearReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2004, Calendar.JULY, 10, 13, 45, 0);
+        cala.set(Calendar.MILLISECOND, 0);
+        calb.set(2004, Calendar.JULY, 9, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
+    public void testIsSameLocalTime_yearReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2014, Calendar.JANUARY, 1, 13, 45, 0);
+        cala.set(Calendar.MILLISECOND, 0);
+        cala.set(Calendar.DAY_OF_YEAR, 1);
+        cala.set(Calendar.MILLISECOND, 0);
+        calb.set(2004, Calendar.JANUARY, 1, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        calb.set(Calendar.DAY_OF_YEAR, 1);
+        calb.set(Calendar.MILLISECOND, 0);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
+    public void testIsSameLocalTime_eraReturnFalse() {
+        final GregorianCalendar cala = new GregorianCalendar(TimeZone.getTimeZone("GMT+1"));
+        final GregorianCalendar calb = new GregorianCalendar(TimeZone.getTimeZone("GMT-1"));
+        cala.set(2004, Calendar.JANUARY, 1, 13, 45, 0);
+        cala.set(Calendar.MILLISECOND, 0);
+        cala.set(Calendar.DAY_OF_YEAR, 1);
+        cala.set(Calendar.ERA, GregorianCalendar.AD);
+        calb.set(2004, Calendar.JANUARY, 1, 13, 45, 0);
+        calb.set(Calendar.MILLISECOND, 0);
+        calb.set(Calendar.DAY_OF_YEAR, 1);
+        calb.set(Calendar.ERA, GregorianCalendar.BC);
+        assertFalse(DateUtils.isSameLocalTime(cala, calb));
+    }
+
+    @Test
     public void testIsSameLocalTime_CalNotNullNull() {
         assertThrows(NullPointerException.class, () -> DateUtils.isSameLocalTime(Calendar.getInstance(), null));
     }


### PR DESCRIPTION
improve its branch overage from 56% to 93%

This branch can pass "mvn" and "mvn test" and build success on my computer.

Before:
![image](https://github.com/LottaJohnsson/commons-lang/assets/64673408/37c77d84-447e-48a9-87a6-4850b7724090)

After:
![image](https://github.com/LottaJohnsson/commons-lang/assets/64673408/9af961d3-b4a0-478b-95d5-31d674f99c36)

fix #18 
