### PR TITLE
Add tests to improve branch coverage in FastDatePrinter, FastDateParser, and StopWatch classes

### DIFF
--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -703,6 +703,13 @@ public class FastDateParserTest extends AbstractLangTest {
         }
     }
 
+    //Cover unsupported locale in parse method
+    @Test
+    public void testParseUnsupportedLocale() {
+        final DateParser fdp = getInstance(null, "dd MMM yyyy", TimeZones.GMT, new Locale("ja", "JP", "JP"));
+        assertThrows(ParseException.class, () -> fdp.parse("14 avr 2014"));
+    }
+
     private void validateSdfFormatFdpParseEquality(final String formatStr, final Locale locale, final TimeZone timeZone,
         final FastDateParser dateParser, final Date inDate, final int year, final Date csDate) throws ParseException {
         final SimpleDateFormat sdf = new SimpleDateFormat(formatStr, locale);

--- a/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java
@@ -703,7 +703,7 @@ public class FastDateParserTest extends AbstractLangTest {
         }
     }
 
-    //Cover unsupported locale in parse method
+    //Cover requirement that unsupported locale in parse method throws ParseException
     @Test
     public void testParseUnsupportedLocale() {
         final DateParser fdp = getInstance(null, "dd MMM yyyy", TimeZones.GMT, new Locale("ja", "JP", "JP"));

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -445,4 +445,24 @@ public class FastDatePrinterTest extends AbstractLangTest {
         assertEquals("2021", printer4DigitAnotherFallback.format(cal));
         assertEquals("21", printer2Digits.format(cal));
     }
+
+    // Cover all negative branches in equals method
+    @Test
+    public void testFullNegativeBranchesEquals() {
+        FastDatePrinter p1 = new FastDatePrinter(YYYY_MM_DD, NEW_YORK, Locale.US);
+        FastDatePrinter p2 = new FastDatePrinter(YYYY_MM_DD, INDIA, Locale.US);
+        FastDatePrinter p3 = new FastDatePrinter(YYYY_MM_DD, NEW_YORK, new Locale("sv", "SE"));
+        assertNotEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertNotEquals(p2, p3);
+    }
+
+    // Cover invalid input to format methods
+    @Test
+    public void testFormatInvalidObject() {
+        final FastDatePrinter printer = new FastDatePrinter(YYYY_MM_DD, NEW_YORK, Locale.US);
+        assertThrows(IllegalArgumentException.class, () -> printer.format(new Object()));
+        assertThrows(IllegalArgumentException.class, () -> printer.format(new Object(), new StringBuffer(), new FieldPosition(0))); //check
+    }
+
 }

--- a/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java
@@ -446,7 +446,7 @@ public class FastDatePrinterTest extends AbstractLangTest {
         assertEquals("21", printer2Digits.format(cal));
     }
 
-    // Cover all negative branches in equals method
+    // Cover requirement that equals method returns false for all negative branches
     @Test
     public void testFullNegativeBranchesEquals() {
         FastDatePrinter p1 = new FastDatePrinter(YYYY_MM_DD, NEW_YORK, Locale.US);
@@ -457,7 +457,7 @@ public class FastDatePrinterTest extends AbstractLangTest {
         assertNotEquals(p2, p3);
     }
 
-    // Cover invalid input to format methods
+    // Cover requirement that invalid Object input to format methods throws IllegalArgumentException
     @Test
     public void testFormatInvalidObject() {
         final FastDatePrinter printer = new FastDatePrinter(YYYY_MM_DD, NEW_YORK, Locale.US);

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -372,4 +372,11 @@ public class StopWatchTest extends AbstractLangTest {
         final String splitStr = watch.toString();
         assertEquals(12 + MESSAGE.length() + 1, splitStr.length(), "Formatted split string not the correct length");
     }
+
+    //Cover illegal call to getStopTime of unstarted StopWatch
+    @Test
+    public void testGetIllegalStopTime() {
+        final StopWatch watch = new StopWatch();
+        assertThrows(IllegalStateException.class, watch::getStopTime);
+    }
 }

--- a/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
+++ b/src/test/java/org/apache/commons/lang3/time/StopWatchTest.java
@@ -373,7 +373,7 @@ public class StopWatchTest extends AbstractLangTest {
         assertEquals(12 + MESSAGE.length() + 1, splitStr.length(), "Formatted split string not the correct length");
     }
 
-    //Cover illegal call to getStopTime of unstarted StopWatch
+    //Cover requirement that illegal call to getStopTime of unstarted StopWatch throws IllegalStateException
     @Test
     public void testGetIllegalStopTime() {
         final StopWatch watch = new StopWatch();


### PR DESCRIPTION
Fix #16 
Add 4 new tests to improve branch coverage in FastDatePrinter, FastDateParser, and StopWatch classes as identified by Jacoco coverage report.
Specifically:
1. Cover all negative branches of equals method in FastDatePrinter
2. Cover invalid input to format methods in FastDatePrinter
3. Cover unsupported locale in parse method in FastDateParser
4. Cover illegal call to getStopTime method in StopWatch